### PR TITLE
Default checkin codes to be enabled when created through the site

### DIFF
--- a/app/controllers/admin/check_in_codes_controller.rb
+++ b/app/controllers/admin/check_in_codes_controller.rb
@@ -15,6 +15,7 @@ class Admin::CheckInCodesController < Admin::BaseController
 
   def create
     @check_in_code = CheckInCode.new(check_in_code_params)
+    @check_in_code.enabled = true
     if @check_in_code.save
       flash[:info] = "Your check in code was created."
       redirect_to admin_check_in_code_path(@check_in_code)


### PR DESCRIPTION
This is fixed because checkin codes are usually created on site so it is annoying to take a few clicks to turn it on.